### PR TITLE
fix (simple_make):  added ffmpeg-devel bits | updated sqlcipher again…

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -184,15 +184,28 @@ sudo apt-get install build-essential qt5-qmake qt5-default qttools5-dev-tools li
 
 <a name="fedora-other-deps" />
 #### Fedora:
+**Note ffmpeg-devel requires enabling / using rpmfusion-free repo (enable via  dnf config-manager)(!).**
+
+*Valid Keys* 
+
+F22:  97F4D1C1  | 5065 885A 371C 6200 3ED7  AC4F 81C9 B423 97F4 D1C1
+
+F23:  E051B67E  | 1E0D 69F0 77CA 4960 C32C  17E2 5B03 78C0 E051 B67E
+
 **Note that sqlcipher is not included in Fedora(!).**
 
-**This means that you have to compile sqlcipher yourself, otherwise compiling qTox will fail.**
+*This means that you have to compile sqlcipher yourself, otherwise compiling qTox will fail.*
+
+*Go to [sqlcipher](#sqlcipher) section to compile it.*
+
 ```bash
-sudo dnf groupinstall "Development Tools"  (can also use sudo dnf install @"Development Tools")
-sudo dnf install qt-devel qt-doc qt-creator qt5-qtsvg qt5-qtsvg-devel openal-soft-devel libXScrnSaver-devel qrencode-devel ffmpeg-devel qtsingleapplication qt5-linguist gtk2-devel
+sudo dnf install @"Development Tools" && \
+sudo dnf config-manager \
+--add-repo=download1.rpmfusion.org/free/fedora/rpmfusion-free-release-23.noarch.rpm && \
+sudo dnf install qt-devel qt-doc qt-creator qt5-qtsvg qt5-qtsvg-devel openal-soft-devel \
+libXScrnSaver-devel qrencode-devel ffmpeg-devel qtsingleapplication qt5-linguist gtk2-devel
 ```
 
-**Go to [sqlcipher](#sqlcipher) section to compile it.**
 
 <a name="opensuse-other-deps" />
 #### openSUSE:
@@ -296,6 +309,7 @@ If you wish to explictly link sqlcipher statically or dynamically use:
 ```
 git clone https://github.com/sqlcipher/sqlcipher
 cd sqlpcipher
+autoreconf -if
 ./configure --enable-tempstore=yes CFLAGS="-DSQLITE_HAS_CODEC" \
     LDFLAGS="/opt/local/lib/libcrypto.a"
 make
@@ -307,6 +321,7 @@ cd ..
 ```
 git clone https://github.com/sqlcipher/sqlcipher
 cd sqlcipher
+autoreconf -if
 ./configure --enable-tempstore=yes CFLAGS="-DSQLITE_HAS_CODEC" \
     LDFLAGS="-lcrypto"
 make

--- a/simple_make.sh
+++ b/simple_make.sh
@@ -14,13 +14,13 @@ elif which pacman; then
         git base-devel qt5 opencv openal libxss qrencode opus libvpx \
         libsodium
 elif which dnf; then
-    sudo dnf group install \
-        "Development Tools"
+    sudo dnf install \
+        @"Development Tools" https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-23.noarch.rpm && \
     sudo dnf install \
         git qt-devel qt-doc qt-creator qt5-qtsvg opencv-devel \
         openal-soft-devel libXScrnSaver-devel qrencode-devel \
         opus-devel libvpx-devel qt5-qttools-devel glib2-devel \
-        gdk-pixbuf2-devel gtk2-devel libsodium-devel
+        gdk-pixbuf2-devel gtk2-devel libsodium-devel ffmpeg-devel 
 elif which zypper; then
     sudo zypper in \
         git patterns-openSUSE-devel_basis libqt5-qtbase-common-devel \


### PR DESCRIPTION
… (Fedora)
- add rpmfusion-free repo so ffmpeg-devel install (compile or  simple-make.sh) no longer fails, and  stays up to date
- add autoreconf -if to reduce conflicts on initial compiles -- reduces issues if running in portable mode with groupchats
